### PR TITLE
options edit css: added overflow for .main--edit__form

### DIFF
--- a/src/component/view/option-edit/style.scss
+++ b/src/component/view/option-edit/style.scss
@@ -9,6 +9,7 @@
         // Expand to remaining height
         display: flex;
         flex-direction: column;
+        overflow-x: auto;
 
         .react-codemirror2,
         .datagrid {


### PR DESCRIPTION
In kiwi browser on Android the page shrinks to very small size if the editor contains too long line. Adding overflow prevents this.